### PR TITLE
fix: correct shell syntax for tag detection in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
           echo "Manual deployment with version bump: ${{ github.event.inputs.version_type }}"
           echo "should_bump=true" >> $GITHUB_OUTPUT
           echo "bump_type=${{ github.event.inputs.version_type }}" >> $GITHUB_OUTPUT
-        elif startsWith(github.ref, 'refs/tags/v'); then
+        elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
           # Tag-based deployment - extract version from tag
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           echo "Tag-based deployment: $TAG_VERSION"


### PR DESCRIPTION
- Replace startsWith() function with proper shell pattern matching
- Use [[ "${{ github.ref }}" == refs/tags/v* ]] instead
- This fixes the syntax error: unexpected token github.ref

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made
- [ ] Updated source code
- [ ] Updated tests
- [ ] Updated documentation
- [ ] Updated dependencies

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Related Issues
Fixes #(issue number)

## Additional Notes
Any additional information that reviewers should know.
